### PR TITLE
fix env variables for selfhosting

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,7 @@
 git pull origin main
 
 # Set the environmental variables
+export $(xargs <.env)
 export NEXT_PUBLIC_FIREBASE_CONFIG='{}'
 export NEXT_PUBLIC_LOGIN_WITH_APPLE='no'
 export NEXT_PUBLIC_LOGIN_WITH_FACEBOOK='no'

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,7 +57,7 @@ app.get('/auth', (req, res) => {
 })
 
 app.post('/auth/login', async (req, res) => {
-  if (useFirebase) {
+  if (useFirebase !== 'no') {
     return res.sendStatus(403)
   }
   const token = req.body.token


### PR DESCRIPTION
## What did you do and why?

Read the env vars at the beginning of the script as well to be able to resolve them while exporting other env vars (specifically HASURA_GRAPHQL_JWT_SECRET needs JWT_SIGNING_SECRET right now)

Use a string comparison for var useFirebase, as it was a string var that would return true in a boolean context, even if set to "no". Maybe there's a more elegant way to do this.