### PR TITLE
fix typo in nginx config

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ http {
 
       location /auth {
           # Authentication server (Express.js)
-          reverse_proxy localhost:3001
+          proxy_pass localhost:3001;
       }
 
       location /healthz {


### PR DESCRIPTION
## What did you do and why?

The nginx config in the README for proxying the newly added auth server had some typos.
