### PR TITLE
Forward variables from '/auth/graphql' to hasura

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -102,7 +102,7 @@ app.post('/auth/graphql', async (req, res) => {
     const result = await request(
       graphqlUrl,
       req.body.query,
-      {},
+      req.body.variables ? req.body.variables : {},
       {
         'X-Hasura-Admin-Secret': adminSecret || '',
         'X-Hasura-Role': 'user',


### PR DESCRIPTION
The documentation instructs the user to use '/auth/graphql' instead of '/v1/graphql'. I noticed that I was unable to perform any mutations using that endpoint though. It appears the variables send as part of the mutation aren't forwarded to Hasura. 

If you see any problems in this proposed solution let me know.
