### PR TITLE
Switch to only logging in with the apiToken

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
     "nosniff",
     "publickey",
     "storeon",
+    "tcenter",
     "timestamptz",
     "uniqby"
   ]

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ http {
 
 > Note: Clean Slate uses the default `postgres` user and `postgres` database. It runs this database, Postgres 15, on port `5432` via Docker Compose. If you do not like this behavior, you must create your own `docker-compose.yml`. Then, run `export COMPOSE_FILE=<your-custom-file.yml>; git pull origin main; bash deploy.sh`
 
-5.  Go to the `https://<your-domain>/console`. Log in with your `HASURA_GRAPHQL_ADMIN_SECRET` defined in your `.env`. Click `Data`, then `public`, then `profiles`, then `Insert Row`. On this screen, click `Save`. This will create a new Profile. Click to `Browse Rows`. Take note of the `authId` of the row you just made. That is your (very long) password to log in. If you want to create another user, follow the same procedure.
+5.  Go to the `https://<your-domain>/console`. Log in with your `HASURA_GRAPHQL_ADMIN_SECRET` defined in your `.env`. Click `Data`, then `public`, then `profiles`, then `Insert Row`. On this screen, click `Save`. This will create a new Profile. Click to `Browse Rows`. Take note of the `apiToken` of the row you just made. That is your (very long) password to log in. If you want to create another user, follow the same procedure. Do not share this token with anyone else. It will enable them to access you account.
 
-6.  You can now log in to `https://<your-domain>` with that password.
+6.  You can now log in to `https://<your-domain>` with that token.
 
 7.  To deploy the newest version of Clean Slate, run `git pull origin main; bash deploy.sh` again. Remember to check [GitHub Releases](https://github.com/successible/cleanslate/releases) before you deploy!
 

--- a/seeds/default/user.sql
+++ b/seeds/default/user.sql
@@ -1,3 +1,3 @@
 SET check_function_bodies = false;
 DELETE FROM public.profiles;
-INSERT INTO public.profiles ("authId") VALUES ('22140ebd-0d06-46cd-8d44-aff5cb7e7101');
+INSERT INTO public.profiles ("authId", "apiToken") VALUES ('3ba0e6b5-dd17-4924-a054-5962db2776da', '22140ebd-0d06-46cd-8d44-aff5cb7e7101');

--- a/src/components/login/TokenLoginButtons.tsx
+++ b/src/components/login/TokenLoginButtons.tsx
@@ -11,6 +11,7 @@ import { LegalDisclaimer } from './LegalDisclaimer'
 
 export const TokenLoginButtons = () => {
   const [token, setToken] = useState('')
+  const noMatch = 'No matching profile found! Make sure to login with apiToken, not authId.'
 
   return (
     <form
@@ -46,10 +47,10 @@ export const TokenLoginButtons = () => {
                 login()
                 getStore().dispatch('updateUser', { token })
               } else {
-                toast.error('No matching profile found!')
+                toast.error(noMatch)
               }
             } catch {
-              toast.error('No matching profile found!')
+              toast.error(noMatch)
             }
           } else {
             toast.error('You must enter your token!')
@@ -69,7 +70,7 @@ export const TokenLoginButtons = () => {
       >
         <div>
           To create an account, the admin must use the Hasura Console to make a
-          profile. The token is the authId of the profile. To learn more about
+          profile. The token is the apiToken of the profile. To learn more about
           the app,{' '}
           <a href="https://cleanslate.sh/" target="_blank" rel="noreferrer">
             go here.

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,8 +73,6 @@ app.post('/auth/login', async (req, res) => {
   }
 
   const profiles = await getProfiles(token)
-  console.log(`Profiles ${profiles}`)
-
   if (profiles.length === 1) {
     const authId = profiles[0].authId
     const customClaims = {


### PR DESCRIPTION
## What did you do and why?

- Switch to only logging in with the apiToken. That way, the JSON Web Token (JWT) does not contain the equivalent of the password, only the id (authId), which is not sensitive. To be clear, the JWT was always sensitive (which is why it was only sent over HTTPS) and should not have been shared. However, I think removing the sensitive information from the payload is a good idea. Now, the only time the password (apiToken) is used is either to create the JWT or to make an API request.
