### PR TITLE
Switch to node:lts-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM node:lts AS builder
+FROM node:lts-slim AS builder
+
+# Update any dependencies bundled with the container
+
+RUN apt-get update -y; apt-get upgrade -y;
 
 # Install the dependencies needed to build Clean Slate
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,4 +1,8 @@
-FROM node:lts
+FROM node:lts-slim
+
+# Update any dependencies bundled with the container
+
+RUN apt-get update -y; apt-get upgrade -y;
 
 WORKDIR /app
 


### PR DESCRIPTION
## What did you do and why?

- Switch to node:lts-slim to reduce vulnerability surface area and reduce image size
