### PR TITLE
Assorted fixes for the authentication server.

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -3,16 +3,7 @@
 if [[ $CI != "true" ]]; then
 
 echo "=> Kill the local version of Clean Slate..."
-
-pkill -9 -f "hasura console"
-pkill -9 -f "next dev"
-pkill -9 -f "next-router-worker"
-pkill -9 -f "next-server"
-pkill -9 -f "npm exec tsc --watch"
-pkill -9 -f "server.js"
-pkill -9 -f "tsc --watch"
-pkill -9 -f "caddy"
-pkill -9 -f "nginx"
+bash kill.sh
 
 export NEXT_PUBLIC_VERSION="XXX"
 export NEXT_PUBLIC_HASURA_DOMAIN="localhost"

--- a/kill.sh
+++ b/kill.sh
@@ -1,0 +1,10 @@
+pkill -9 -f "hasura console"
+pkill -9 -f "next dev"
+pkill -9 -f "next-router-worker"
+pkill -9 -f "next-server"
+pkill -9 -f "npm exec tsc --watch"
+pkill -9 -f "server.js"
+pkill -9 -f "tsc --watch"
+
+sudo pkill -9 -f "caddy"
+sudo pkill -9 -f "nginx"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ms": "2.1.3",
     "next": "15.3.5",
     "pino-http": "10.5.0",
+    "pino-pretty": "13.1.1",
     "pluralize": "8.0.0",
     "quick-score": "0.2.0",
     "react": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       pino-http:
         specifier: 10.5.0
         version: 10.5.0
+      pino-pretty:
+        specifier: 13.1.1
+        version: 13.1.1
       pluralize:
         specifier: 8.0.0
         version: 8.0.0
@@ -2698,6 +2701,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
 
@@ -3011,6 +3017,9 @@ packages:
     resolution: {integrity: sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==}
     engines: {node: '>=18.0.0'}
 
+  fast-copy@3.0.2:
+    resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3023,6 +3032,9 @@ packages:
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
@@ -3370,6 +3382,9 @@ packages:
   helmet@8.1.0:
     resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
     engines: {node: '>=18.0.0'}
+
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -3871,6 +3886,10 @@ packages:
 
   jose@6.0.12:
     resolution: {integrity: sha512-T8xypXs8CpmiIi78k0E+Lk7T2zlK4zDyg+o1CZ4AkOHgDg98ogdP2BeZ61lTFKFyoEwJ9RgAgN+SdM3iPgNonQ==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
@@ -4591,6 +4610,10 @@ packages:
   pino-http@10.5.0:
     resolution: {integrity: sha512-hD91XjgaKkSsdn8P7LaebrNzhGTdB086W3pyPihX0EzGPjq5uBJBXo4N5guqNaK6mUjg9aubMF7wDViYek9dRA==}
 
+  pino-pretty@13.1.1:
+    resolution: {integrity: sha512-TNNEOg0eA0u+/WuqH0MH0Xui7uqVk9D74ESOpjtebSQYbNWJk/dIxCXIxFsNfeN53JmtWqYHP2OrIZjT/CBEnA==}
+    hasBin: true
+
   pino-std-serializers@7.0.0:
     resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
 
@@ -4702,6 +4725,9 @@ packages:
 
   pstree.remy@1.1.8:
     resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
+
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4940,6 +4966,9 @@ packages:
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  secure-json-parse@4.0.0:
+    resolution: {integrity: sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==}
 
   semver-diff@3.1.1:
     resolution: {integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==}
@@ -5211,6 +5240,10 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-json-comments@5.0.2:
+    resolution: {integrity: sha512-4X2FR3UwhNUE9G49aIsJW5hRRR3GXGTBTZRMfv568O60ojM8HcWjV/VxAxCDW3SUND33O6ZY66ZuRcdkj73q2g==}
+    engines: {node: '>=14.16'}
 
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
@@ -8781,6 +8814,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  dateformat@4.6.3: {}
+
   dayjs@1.11.13: {}
 
   debug@2.6.9:
@@ -9177,6 +9212,8 @@ snapshots:
 
   farmhash-modern@1.1.0: {}
 
+  fast-copy@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -9184,6 +9221,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-redact@3.5.0: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.0.6: {}
 
@@ -9719,6 +9758,8 @@ snapshots:
   heap-js@2.6.0: {}
 
   helmet@8.1.0: {}
+
+  help-me@5.0.0: {}
 
   highlight.js@10.7.3: {}
 
@@ -10394,6 +10435,8 @@ snapshots:
   jose@4.15.9: {}
 
   jose@6.0.12: {}
+
+  joycon@3.1.1: {}
 
   js-cookie@3.0.5: {}
 
@@ -11114,6 +11157,22 @@ snapshots:
       pino-std-serializers: 7.0.0
       process-warning: 5.0.0
 
+  pino-pretty@13.1.1:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 3.0.2
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pump: 3.0.3
+      secure-json-parse: 4.0.0
+      sonic-boom: 4.2.0
+      strip-json-comments: 5.0.2
+
   pino-std-serializers@7.0.0: {}
 
   pino@9.7.0:
@@ -11240,6 +11299,11 @@ snapshots:
   proxy-from-env@1.1.0: {}
 
   pstree.remy@1.1.8: {}
+
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -11504,6 +11568,8 @@ snapshots:
       '@parcel/watcher': 2.5.1
 
   scheduler@0.26.0: {}
+
+  secure-json-parse@4.0.0: {}
 
   semver-diff@3.1.1:
     dependencies:
@@ -11863,6 +11929,8 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-json-comments@5.0.2: {}
 
   strnum@1.1.2:
     optional: true

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,8 @@ type AnyResponse = any
 const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET
 const domain = process.env.NEXT_PUBLIC_HASURA_DOMAIN
 const isProduction = process.env.NODE_ENV === 'production'
+const isDevelopment = !isProduction
+
 const signingKey = process.env.JWT_SIGNING_SECRET
 const useFirebase = process.env.NEXT_PUBLIC_USE_FIREBASE === 'true'
 
@@ -21,13 +23,20 @@ if (!adminSecret && !useFirebase) {
 
 const app = express()
 app.use(express.json())
-app.use(logger())
+app.use(logger(isDevelopment ? { transport: { target: 'pino-pretty' } } : {}))
 isProduction && app.use(helmet())
 
 const port = 3001
 const graphqlUrl = isProduction
-  ? 'http://graphql-server:8080/v1/graphql'
-  : 'https://localhost/v1/graphql'
+  ? // We need Docker container to Docker container communication (over HTTP) here.
+    // In other words, the authentication server container to Hasura container.
+    // If you have the autentication server go through Caddy to the Hasura server, it will strip the X-Hasura-Role
+    // This is usually exactly what you want for security! However, for the /auth/graphql route
+    // It is a problem, as stripping out X-Hasura-Role will have Hasura default to the admin role
+    // Simply because you are also passing X-Hasura-Admin-Secret at the same time.
+    // In this scenario, you would have the request made with admin permissions, effectively.
+    'http://graphql-server:8080/v1/graphql'
+  : 'http://localhost:8080/v1/graphql'
 
 const getProfiles = async (token: string) => {
   const document = `
@@ -59,7 +68,9 @@ const getProfiles = async (token: string) => {
     },
   })
 
-  return response.data.data.profiles as [{ authId: string; id: string }]
+  return (response?.data?.data?.profiles || []) as [
+    { authId: string; id: string },
+  ]
 }
 
 app.get('/auth', (_req, res): AnyResponse => {
@@ -71,8 +82,8 @@ app.post('/auth/login', async (req, res): Promise<AnyResponse> => {
     console.log('This endpoint is disabled because Firebase is enabled.')
     return res.sendStatus(403)
   }
-  const token = req.body.token
-  if (!req.body.token) {
+  const token = req?.body?.token
+  if (!token) {
     console.log('This endpoint requires you to pass a token.')
     return res.sendStatus(422)
   }
@@ -103,11 +114,12 @@ app.post('/auth/login', async (req, res): Promise<AnyResponse> => {
 })
 
 app.post('/auth/graphql', async (req, res): Promise<AnyResponse> => {
-  const token = req.body.token
-  if (!req.body.token) {
+  const token = req?.body?.token
+  const query = req?.body?.query
+  if (!token) {
     return res.sendStatus(422)
   }
-  if (!req.body.query) {
+  if (!query) {
     return res.sendStatus(422)
   }
   const profiles = await getProfiles(token)
@@ -131,6 +143,7 @@ app.post('/auth/graphql', async (req, res): Promise<AnyResponse> => {
     })
     return res.send(result.data.data)
   }
+  console.log('No profile was found matching that token.')
   return res.sendStatus(403)
 })
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,16 +41,11 @@ const graphqlUrl = isProduction
 const getProfiles = async (token: string) => {
   const document = `
     query GET_PROFILES($token: uuid!) {
-      profiles(
-        where: {
-          _or: [{ apiToken: { _eq: $token } }]
-        }
-      ) {
+      profiles(where: {apiToken: {_eq: $token}}) {
         authId
         id
       }
-    }
-  `
+    }`
 
   const response = await axios({
     url: graphqlUrl,


### PR DESCRIPTION
## What did you do and why?

- **Enhancement & Security**: Ensure that filtering works properly for `/auth/graphql` when running Clean Slate in development mode on your local machine. This bug does not impact Clean Slate in production mode.

- **Enhancement**: Improved the error messages from passing invalid tokens, missing body parameters, etc. in the authentication server.

- **Enhancement**: Added `pino-pretty` in development mode in the authentication server.

- **Enhancement**: Added `kill.sh` to make it easier to kill `caddy` and `nginx` in development mode.
